### PR TITLE
Add expense CRUD APIs with auth protection and validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,0 @@
-PORT=5000
-MONGO_URI=your_mongodb_connection_string_here

--- a/backend/controllers/expenseController.js
+++ b/backend/controllers/expenseController.js
@@ -1,0 +1,134 @@
+import Expense from "../models/Expense.js";
+
+/*
+  @desc    Add a new expense
+  @route   POST /expenses
+  @access  Private (Authenticated users only)
+*/
+export const addExpense = async (req, res) => {
+    try {
+        // Extract expense details from request body
+        const { amount, category, date, description } = req.body;
+
+        // Create a new expense linked to the logged-in user
+        const expense = await Expense.create({
+            user: req.user._id,   // comes from auth middleware
+            amount,
+            category,
+            date,
+            description,
+        });
+
+        // Send success response
+        res.status(201).json(expense);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({
+            message: "Failed to add expense",
+        });
+    }
+};
+
+/*
+  @desc    Get all expenses of the logged-in user
+  @route   GET /expenses
+  @access  Private
+*/
+export const getExpenses = async (req, res) => {
+    try {
+        // Fetch expenses belonging only to the logged-in user
+        const expenses = await Expense.find({ user: req.user._id })
+            .sort({ date: -1 }); // latest expenses first
+
+        res.status(200).json(expenses);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({
+            message: "Failed to fetch expenses",
+        });
+    }
+};
+
+/*
+  @desc    Update an existing expense
+  @route   PUT /expenses/:id
+  @access  Private
+*/
+export const updateExpense = async (req, res) => {
+    try {
+        const expenseId = req.params.id;
+
+        // Find expense by ID
+        const expense = await Expense.findById(expenseId);
+
+        // Check if expense exists
+        if (!expense) {
+            return res.status(404).json({
+                message: "Expense not found",
+            });
+        }
+
+        // Ensure the expense belongs to the logged-in user
+        if (expense.user.toString() !== req.user._id.toString()) {
+            return res.status(401).json({
+                message: "Not authorized to update this expense",
+            });
+        }
+
+        // Update fields (fallback to existing values)
+        expense.amount = req.body.amount ?? expense.amount;
+        expense.category = req.body.category ?? expense.category;
+        expense.date = req.body.date ?? expense.date;
+        expense.description = req.body.description ?? expense.description;
+
+        // Save updated expense
+        const updatedExpense = await expense.save();
+
+        res.status(200).json(updatedExpense);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({
+            message: "Failed to update expense",
+        });
+    }
+};
+
+/*
+  @desc    Delete an expense
+  @route   DELETE /expenses/:id
+  @access  Private
+*/
+export const deleteExpense = async (req, res) => {
+    try {
+        const expenseId = req.params.id;
+
+        // Find expense by ID
+        const expense = await Expense.findById(expenseId);
+
+        // Check if expense exists
+        if (!expense) {
+            return res.status(404).json({
+                message: "Expense not found",
+            });
+        }
+
+        // Ensure the expense belongs to the logged-in user
+        if (expense.user.toString() !== req.user._id.toString()) {
+            return res.status(401).json({
+                message: "Not authorized to delete this expense",
+            });
+        }
+
+        // Delete the expense
+        await expense.deleteOne();
+
+        res.status(200).json({
+            message: "Expense deleted successfully",
+        });
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({
+            message: "Failed to delete expense",
+        });
+    }
+};

--- a/backend/middlewares/expenseValidation.js
+++ b/backend/middlewares/expenseValidation.js
@@ -1,0 +1,54 @@
+import { body, validationResult } from "express-validator";
+
+/*
+  Validation rules for creating/updating expenses
+*/
+export const validateExpense = [
+  // Amount must exist and be a positive number
+  body("amount")
+    .notEmpty()
+    .withMessage("Amount is required")
+    .isFloat({ gt: 0 })
+    .withMessage("Amount must be a number greater than 0"),
+
+  // Category must exist and be one of allowed values
+  body("category")
+    .notEmpty()
+    .withMessage("Category is required")
+    .isIn([
+      "Food",
+      "Transport",
+      "Rent",
+      "Utilities",
+      "Shopping",
+      "Health",
+      "Entertainment",
+      "Other",
+    ])
+    .withMessage("Invalid category"),
+
+  // Date is optional but must be valid if provided
+  body("date")
+    .optional()
+    .isISO8601()
+    .withMessage("Invalid date format"),
+
+  // Description is optional but should be a string
+  body("description")
+    .optional()
+    .isString()
+    .withMessage("Description must be a string"),
+
+  // Final middleware to check validation result
+  (req, res, next) => {
+    const errors = validationResult(req);
+
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        errors: errors.array().map(err => err.msg),
+      });
+    }
+
+    next();
+  },
+];

--- a/backend/models/Expense.js
+++ b/backend/models/Expense.js
@@ -1,0 +1,98 @@
+import mongoose from "mongoose";
+
+/*
+  Expense Schema
+  --------------
+  This schema represents a single expense entry created by a user.
+  Each expense is linked to one user and is used for:
+  - Expense tracking
+  - Dashboard summaries
+  - Category-wise & month-wise analytics
+*/
+
+const expenseSchema = new mongoose.Schema(
+    {
+        user: {
+            /*
+          user:
+          -----
+          Stores reference to the User who created this expense.
+          This ensures:
+          - Expenses are user-specific
+          - One user cannot access another user's data
+        */
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+        },
+
+        amount: {
+            /*
+          amount:
+          -------
+          Stores the monetary value of the expense.
+          Must be a number and is required.
+          Used for:
+          - Total expense calculation
+          - Monthly & yearly summaries
+        */
+            type: Number,
+            required: true,
+        },
+
+        category: {
+             /*
+          category:
+          ---------
+          Categorizes the expense (Food, Rent, etc.).
+          Enum restricts values to predefined categories,
+          which helps maintain clean data and enables analytics.
+        */
+            type: String,
+            required: true,
+            enum: [
+                "Food",
+                "Transport",
+                "Rent",
+                "Utilities",
+                "Shopping",
+                "Health",
+                "Entertainment",
+                "Other",
+            ],
+        },
+
+        date: {
+            /*
+          date:
+          -----
+          The date on which the expense occurred.
+          Defaults to the current date if not provided.
+          Used for:
+          - Month-wise grouping
+          - Time-based filters
+        */
+            type: Date,
+            default: Date.now,
+            required: true,
+        },
+
+        description: {
+            /*
+          description:
+          ------------
+          Optional text field to add notes about the expense.
+          Example: "Dinner with friends"
+          Trim removes extra whitespace.
+        */
+            type: String,
+            trim: true,
+        },
+    },
+    {
+        timestamps: true, // adds createdAt & updatedAt
+    }
+);
+
+const Expense = mongoose.model("Expense", expenseSchema);
+export default Expense;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,8 +13,9 @@
         "bcryptjs": "^3.0.3",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "express-validator": "^7.3.1",
         "jsonwebtoken": "^9.0.3",
-        "mongoose": "^9.1.2"
+        "mongoose": "^9.1.5"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
@@ -451,6 +452,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.1.tgz",
+      "integrity": "sha512-IGenaSf+DnWc69lKuqlRE9/i/2t5/16VpH5bXoqdxWz1aCpRvEdrBuu1y95i/iL5QP8ZYVATiwLFhwk3EDl5vg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.15.23"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -785,6 +799,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -961,9 +981,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.1.2.tgz",
-      "integrity": "sha512-EdxZ/l+wLIPymy/ODxulg13CaUPpt8RenGmuoNAuRhA5Dgk/QERkUm3U0wOEbAi6ULG08bGDo9sy2tKX0KwxIg==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.1.5.tgz",
+      "integrity": "sha512-N6gypEO+wLmZp8kCYNQmrEWxVMT0KhyHvVttBZoKA/1ngY7aUsBjqHzCPtDgz+i8JAnqMOiEKmuJIDEQu1b9Dw==",
       "license": "MIT",
       "dependencies": {
         "kareem": "3.0.0",
@@ -1518,6 +1538,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,8 +15,9 @@
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "express-validator": "^7.3.1",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.1.2"
+    "mongoose": "^9.1.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/backend/routes/expenseRoutes.js
+++ b/backend/routes/expenseRoutes.js
@@ -1,0 +1,52 @@
+import express from "express";
+
+// Import expense controller functions
+import {
+    addExpense,
+    getExpenses,
+    updateExpense,
+    deleteExpense,
+} from "../controllers/expenseController.js";
+
+// Import auth middleware to protect routes
+import protect  from "../middlewares/authMiddleware.js";
+import { validateExpense } from "../middlewares/expenseValidation.js";
+
+const router = express.Router();
+
+/*
+  Expense Routes
+  --------------
+  All routes are protected.
+  Only authenticated users can access their own expenses.
+*/
+
+/*
+  @route   POST /expenses
+  @desc    Add a new expense
+  @access  Private
+*/
+router.post("/", protect, validateExpense, addExpense); 
+
+/*
+  @route   GET /expenses
+  @desc    Get all expenses of logged-in user
+  @access  Private
+*/
+router.get("/", protect, getExpenses);
+
+/*
+  @route   PUT /expenses/:id
+  @desc    Update a specific expense
+  @access  Private
+*/
+router.put("/:id", protect, validateExpense ,updateExpense);
+
+/*
+  @route   DELETE /expenses/:id
+  @desc    Delete a specific expense
+  @access  Private
+*/
+router.delete("/:id", protect, deleteExpense);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import authRoutes from './routes/authRoutes.js';
 import assetRoutes from "./routes/assetRoutes.js";
+import expenseRoutes from "./routes/expenseRoutes.js";
 
 dotenv.config();    // load .env variables
 
@@ -16,6 +17,8 @@ app.use("/api/auth", authRoutes);
 
 // Asset Routes
 app.use("/api/assets", assetRoutes);
+
+app.use("/api/expenses",expenseRoutes);
 
 // Mongo Connection
 mongoose.connect(process.env.MONGO_URI)


### PR DESCRIPTION
## What this PR does
- Adds Expense model with user ownership
- Implements full CRUD APIs for expenses
- Protects expense routes using JWT auth middleware
- Adds input validation using express-validator

## Why this is needed
- Enables core expense-tracking functionality
- Ensures data isolation per user
- Improves API robustness and security

## How to test
1. Register / login to get JWT token
2. Use token in Authorization header
3. Test:
   - POST /api/expenses
   - GET /api/expenses
   - PUT /api/expenses/:id
   - DELETE /api/expenses/:id
   
   Already tested using postman
